### PR TITLE
= 1.0.1 - April 11, 2019 =

### DIFF
--- a/assets/css/paygate_checkout.css
+++ b/assets/css/paygate_checkout.css
@@ -1,0 +1,62 @@
+/* The popup (background) */
+
+#payPopup {
+    display: block;
+    /* Shows the popup */
+    position: fixed;
+    z-index: 9999999999;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background-color: rgb(0, 0, 0);
+    /* Fallback background color */
+    background-color: rgba(0, 0, 0, 0.6);
+    /* Background color with opacity */
+}
+/* Popup content box */
+
+#payPopupContent {
+    background-color: #fefefe;
+    /* Popup color */
+    margin: auto;
+    margin-top: 30px;
+    padding: 6px;
+    border: 1px solid #888;
+    /* Popup border */
+    border-radius: 10px;
+    max-width: 700px;
+    /* Popup width */
+    height: 90%;
+    /* Popup height: */
+    overflow: auto;
+}
+#payPopupFrame {
+    margin: 0px;
+    padding: 0px;
+    border: none;
+    width: 100%;
+    height: 100%;
+}
+/* The close button */
+
+#payPopupClose {
+    color: #aaa;
+    /* Close button color */
+    float: right;
+    font-size: 28px;
+    /* Close button size */
+    font-weight: bold;
+    margin: 0px;
+    padding: 0px;
+    font-family: 'Times New Roman';
+    line-height: 15px;
+    height: 15px;
+}
+#payPopupClose:hover, #payPopupClose:focus {
+    color: black;
+    /* Close button hover color */
+    text-decoration: none;
+    cursor: pointer;
+}

--- a/assets/js/paygate_checkout.js
+++ b/assets/js/paygate_checkout.js
@@ -1,0 +1,56 @@
+jQuery(function() {
+    jQuery.ajaxSetup({
+        complete: function(xhr, textStatus) {
+            var result = JSON.parse(xhr.responseText);
+            if (result.VERSION == 21) {
+                jQuery('.woocommerce-error').remove();
+                initPayPopup(result);
+                return false;
+            }
+            return;
+        }
+    });
+    jQuery(document).ajaxComplete(function() {
+        if (jQuery('body').hasClass('woocommerce-checkout') || jQuery('body').hasClass('woocommerce-cart')) {
+            jQuery('html, body').stop();
+        }
+    });
+});
+
+function initPayPopup(result) {
+    jQuery("body").append("<div id='payPopup'></div>");
+    jQuery("#payPopup").append("<div id='payPopupContent'></div>");
+    var xy = '';
+    for (var key in result) {
+        if (result.hasOwnProperty(key)) {
+
+            xy += "<input type='hidden' name='" +key+ "' value='" + result[key] + "'>"; 
+        }
+    }
+    jQuery("#payPopupContent").append("<form target='myIframe' name='paygate_checkout' id='paygate_checkout' action='https://www.paygate.co.za/paysubs/process.trans' method='post'>" + xy + "</form><iframe style='width:100%;height:100%;' id='payPopupFrame' name='myIframe'  src='#' ></iframe><script type='text/javascript'>document.getElementById('paygate_checkout').submit();</script>");
+}
+jQuery(document).on('submit', 'form#order_review', function(e) {
+    jQuery("#place_order").attr("disabled", "disabled");
+    var contine = true;
+    if( jQuery('#terms').length ){
+        if( !jQuery("#terms").is(":checked") == true) {
+            contine = false;
+        };
+    }
+    if ( contine && jQuery('#payment_method_paygate').length && jQuery("#payment_method_paygate").is(":checked") == true ) {
+        e.preventDefault();
+        jQuery.ajax({
+            'url': wc_add_to_cart_params.ajax_url,
+            'type': 'POST',
+            'dataType': 'json',
+            'data': {
+                'action': 'order_pay_payment',
+                'order_id': paygate_checkout_js.order_id
+            },
+            'async': false
+        }).complete(function(result) {
+            var result = JSON.parse(result);
+            initPayPopup(result);
+        });
+    }
+});

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,11 @@
+= 1.0.1 - April 11, 2019 =
+
+* Allow for either iFrame or Redirect implementation
+* Cater for abandoned carts and allow users to 'edit' cart on failed payment
+* Make cancelled transactions have an order status of 'cancelled'
+* Use add_notice() for store notices
+* Add support for sequential order number plugins (get_order_number and get_id)
+
 = 1.0.0 - February 28, 2019 =
 
 * First Release

--- a/classes/updater.class.php
+++ b/classes/updater.class.php
@@ -1,7 +1,7 @@
 <?php
 
 // Prevent loading this file directly and/or if the class is already defined
-if ( !defined( 'ABSPATH' ) || class_exists( 'WPGitHubUpdater' ) || class_exists( 'WP_GitHub_Updater' ) ) {
+if ( !defined( 'ABSPATH' ) || class_exists( 'WPGitHubUpdater' ) || class_exists( 'WP_GitHub_Updater_PS2' ) ) {
     return;
 }
 
@@ -11,7 +11,7 @@ if ( !defined( 'ABSPATH' ) || class_exists( 'WPGitHubUpdater' ) || class_exists(
  * @version 1.7
  * @author Joachim Kudish <info@jkudish.com>
  * @link http://jkudish.com
- * @package WP_GitHub_Updater
+ * @package WP_GitHub_Updater_PS2
  * @license http://www.gnu.org/copyleft/gpl.html GNU Public License
  * @copyright Copyright (c) 2011-2013, Joachim Kudish
  *
@@ -32,7 +32,7 @@ if ( !defined( 'ABSPATH' ) || class_exists( 'WPGitHubUpdater' ) || class_exists(
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-class WP_GitHub_Updater
+class WP_GitHub_Updater_PS2
 {
 
     /**

--- a/gateway-paygate.php
+++ b/gateway-paygate.php
@@ -4,7 +4,7 @@
  * Plugin Name: PayGate PaySubs2 plugin for WooCommerce
  * Plugin URI: https://github.com/PayGate/PaySubs2_WooCommerce
  * Description: Accept payments for WooCommerce using PayGate's PaySubs2 service
- * Version: 1.0.0
+ * Version: 1.0.1
  * Tested: 5.1.0
  * Author: PayGate (Pty) Ltd
  * Author URI: https://www.paygate.co.za/
@@ -58,7 +58,7 @@ function woocommerce_paysubs2_init()
             'access_token'       => '',
         );
 
-        new WP_GitHub_Updater( $config );
+        new WP_GitHub_Updater_PS2( $config );
 
     }
 


### PR DESCRIPTION
* Allow for either iFrame or Redirect implementation
* Cater for abandoned carts and allow users to 'edit' cart on failed payment
* Make cancelled transactions have an order status of 'cancelled'
* Use add_notice() for store notices
* Add support for sequential order number plugins (get_order_number and get_id)